### PR TITLE
fix: add assumption to executor test

### DIFF
--- a/test/unit/UpgradeManager.t.sol
+++ b/test/unit/UpgradeManager.t.sol
@@ -262,6 +262,7 @@ contract UpgradeManager_Unit_ExecuteMigration is Base {
   function test_revertIfNotExecutor(address _l1Messenger, address _circle, address _executor) public {
     vm.assume(_circle != address(0));
     vm.assume(_executor != address(0));
+    vm.assume(_executor != _user);
 
     upgradeManager.forTest_setMigrationsCircle(_l1Messenger, _circle);
     upgradeManager.forTest_setMigrationsExecutor(_l1Messenger, _executor);


### PR DESCRIPTION
During fuzzing the `executor` address was equal to the `user`´s one, I had to add an assumption.
![image](https://github.com/defi-wonderland/opUSDC/assets/165055168/dea644aa-9c03-4d1f-80f6-13e2648d904b)

