### PR TITLE
chore: remove circle naming for legal reasons

### DIFF
--- a/src/contracts/L1OpUSDCBridgeAdapter.sol
+++ b/src/contracts/L1OpUSDCBridgeAdapter.sol
@@ -14,7 +14,7 @@ contract L1OpUSDCBridgeAdapter is IL1OpUSDCBridgeAdapter, OpUSDCBridgeAdapter {
   uint256 public burnAmount;
 
   /// @inheritdoc IL1OpUSDCBridgeAdapter
-  address public circle;
+  address public newOwner;
 
   /// @inheritdoc IL1OpUSDCBridgeAdapter
   Status public messengerStatus;
@@ -50,35 +50,34 @@ contract L1OpUSDCBridgeAdapter is IL1OpUSDCBridgeAdapter, OpUSDCBridgeAdapter {
 
   /**
    * @notice Initiates the process to migrate the bridged USDC to native USDC
-   * @param _circle The address to transfer ownerships to
+   * @param _newOwner The address to transfer ownerships to
    * @param _minGasLimitReceiveOnL2 Minimum gas limit that the message can be executed with on L2
    * @param _minGasLimitSetBurnAmount Minimum gas limit that the message can be executed with to set the burn amount
    */
   function migrateToNative(
-    address _circle,
+    address _newOwner,
     uint32 _minGasLimitReceiveOnL2,
     uint32 _minGasLimitSetBurnAmount
   ) external onlyOwner {
     // Leave this flow open to resend upgrading flow incase message fails on L2
-
-    // Circle implementation of `transferOwnership` reverts on address(0)
-    if (_circle == address(0)) revert IOpUSDCBridgeAdapter_InvalidAddress();
+    // Circle's USDC implementation of `transferOwnership` reverts on address(0)
+    if (_newOwner == address(0)) revert IOpUSDCBridgeAdapter_InvalidAddress();
 
     // Ensure messaging is enabled
     if (messengerStatus != Status.Active && messengerStatus != Status.Upgrading) {
       revert IOpUSDCBridgeAdapter_MessagingDisabled();
     }
 
-    circle = _circle;
+    newOwner = _newOwner;
     messengerStatus = Status.Upgrading;
 
     ICrossDomainMessenger(MESSENGER).sendMessage(
       LINKED_ADAPTER,
-      abi.encodeWithSignature('receiveMigrateToNative(address,uint32)', _circle, _minGasLimitSetBurnAmount),
+      abi.encodeWithSignature('receiveMigrateToNative(address,uint32)', _newOwner, _minGasLimitSetBurnAmount),
       _minGasLimitReceiveOnL2
     );
 
-    emit MigratingToNative(MESSENGER, _circle);
+    emit MigratingToNative(MESSENGER, _newOwner);
   }
 
   /**
@@ -100,7 +99,7 @@ contract L1OpUSDCBridgeAdapter is IL1OpUSDCBridgeAdapter, OpUSDCBridgeAdapter {
    * @dev The amount is determined by the burnAmount variable, which is set in the setBurnAmount function
    */
   function burnLockedUSDC() external {
-    if (msg.sender != circle) revert IOpUSDCBridgeAdapter_InvalidSender();
+    if (msg.sender != newOwner) revert IOpUSDCBridgeAdapter_InvalidSender();
 
     // If the adapter is not deprecated the burn amount has not been set
     if (messengerStatus != Status.Deprecated) revert IOpUSDCBridgeAdapter_BurnAmountNotSet();
@@ -110,7 +109,7 @@ contract L1OpUSDCBridgeAdapter is IL1OpUSDCBridgeAdapter, OpUSDCBridgeAdapter {
 
     // Set the burn amount to 0
     burnAmount = 0;
-    circle = address(0);
+    newOwner = address(0);
 
     emit MigrationComplete();
   }

--- a/src/interfaces/IL1OpUSDCBridgeAdapter.sol
+++ b/src/interfaces/IL1OpUSDCBridgeAdapter.sol
@@ -87,10 +87,10 @@ interface IL1OpUSDCBridgeAdapter {
   function burnAmount() external view returns (uint256 _burnAmount);
 
   /**
-   * @notice Fetches the address of the Circle contract
-   * @return _circle The address of the Circle contract
+   * @notice Fetches the address of the new owner for the USDC tokens
+   * @return _newOwner The address of the new owner for the USDC tokens
    */
-  function circle() external view returns (address _circle);
+  function newOwner() external view returns (address _newOwner);
 
   /**
    * @notice Fetches the status of the messenger

--- a/test/integration/L1OpUSDCBridgeAdapter.t.sol
+++ b/test/integration/L1OpUSDCBridgeAdapter.t.sol
@@ -193,7 +193,7 @@ contract Integration_Migration is IntegrationBase {
     vm.stopPrank();
 
     assertEq(uint256(l1Adapter.messengerStatus()), uint256(IL1OpUSDCBridgeAdapter.Status.Upgrading));
-    assertEq(l1Adapter.circle(), _circle);
+    assertEq(l1Adapter.newOwner(), _circle);
 
     vm.selectFork(optimism);
 
@@ -241,7 +241,7 @@ contract Integration_Migration is IntegrationBase {
 
     assertEq(MAINNET_USDC.balanceOf(address(l1Adapter)), 0);
     assertEq(l1Adapter.burnAmount(), 0);
-    assertEq(l1Adapter.circle(), address(0));
+    assertEq(l1Adapter.newOwner(), address(0));
   }
 
   function _mintSupplyOnL2() internal {

--- a/test/unit/L1OpUSDCBridgeAdapter.t.sol
+++ b/test/unit/L1OpUSDCBridgeAdapter.t.sol
@@ -17,8 +17,8 @@ contract ForTestL1OpUSDCBridgeAdapter is L1OpUSDCBridgeAdapter {
     burnAmount = _amount;
   }
 
-  function forTest_setCircle(address _circle) external {
-    circle = _circle;
+  function forTest_setNewOwner(address _newOwner) external {
+    newOwner = _newOwner;
   }
 
   function forTest_setMessengerStatus(Status _status) external {
@@ -136,7 +136,7 @@ contract L1OpUSDCBridgeAdapter_Unit_MigrateToNative is Base {
     // Execute
     vm.prank(_owner);
     adapter.migrateToNative(_newOwner, _minGasLimitReceiveOnL2, _minGasLimitSetBurnAmount);
-    assertEq(adapter.circle(), _newOwner, 'Circle should be set to the new owner');
+    assertEq(adapter.newOwner(), _newOwner, 'Circle should be set to the new owner');
     assertEq(
       uint256(adapter.messengerStatus()),
       uint256(IL1OpUSDCBridgeAdapter.Status.Upgrading),
@@ -178,7 +178,7 @@ contract L1OpUSDCBridgeAdapter_Unit_MigrateToNative is Base {
     uint32 _minGasLimitSetBurnAmount
   ) external {
     vm.assume(_newOwner != address(0));
-    adapter.forTest_setCircle(_newOwner);
+    adapter.forTest_setNewOwner(_newOwner);
     adapter.forTest_setMessengerStatus(IL1OpUSDCBridgeAdapter.Status.Upgrading);
 
     _mockAndExpect(
@@ -335,7 +335,7 @@ contract L1OpUSDCBridgeAdapter_Unit_BurnLockedUSDC is Base {
   }
 
   function test_burnAmountNotSet(address _circle) external {
-    adapter.forTest_setCircle(_circle);
+    adapter.forTest_setNewOwner(_circle);
 
     // Execute
     vm.prank(_circle);
@@ -347,7 +347,7 @@ contract L1OpUSDCBridgeAdapter_Unit_BurnLockedUSDC is Base {
    * @notice Check that the burn function is called as expected
    */
   function test_expectedCall(uint256 _burnAmount, address _circle) external {
-    adapter.forTest_setCircle(_circle);
+    adapter.forTest_setNewOwner(_circle);
     adapter.forTest_setMessengerStatus(IL1OpUSDCBridgeAdapter.Status.Deprecated);
 
     vm.assume(_burnAmount > 0);
@@ -366,7 +366,7 @@ contract L1OpUSDCBridgeAdapter_Unit_BurnLockedUSDC is Base {
    */
   function test_resetStorageValues(uint256 _burnAmount, address _circle) external {
     vm.assume(_burnAmount > 0);
-    adapter.forTest_setCircle(_circle);
+    adapter.forTest_setNewOwner(_circle);
     adapter.forTest_setMessengerStatus(IL1OpUSDCBridgeAdapter.Status.Deprecated);
 
     vm.mockCall(
@@ -380,7 +380,7 @@ contract L1OpUSDCBridgeAdapter_Unit_BurnLockedUSDC is Base {
     adapter.burnLockedUSDC();
 
     assertEq(adapter.burnAmount(), 0, 'Burn amount should be set to 0');
-    assertEq(adapter.circle(), address(0), 'Circle should be set to 0');
+    assertEq(adapter.newOwner(), address(0), 'Circle should be set to 0');
   }
 
   /**
@@ -388,7 +388,7 @@ contract L1OpUSDCBridgeAdapter_Unit_BurnLockedUSDC is Base {
    */
   function test_emitEvent(uint256 _burnAmount, address _circle) external {
     vm.assume(_burnAmount > 0);
-    adapter.forTest_setCircle(_circle);
+    adapter.forTest_setNewOwner(_circle);
     adapter.forTest_setMessengerStatus(IL1OpUSDCBridgeAdapter.Status.Deprecated);
 
     vm.mockCall(address(_usdc), abi.encodeWithSignature('burn(address)', address(adapter)), abi.encode(true));


### PR DESCRIPTION
# 🤖 Linear

Closes OPT-XXX

### Notes
- Keep the wording "circle" out of the core contracts to avoid legal issues
- For testing its not an issue