### PR TITLE
docs: update testnet deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ Chain operators can use the Bridged USDC Standard for the OP Stack to get Bridge
 > :exclamation: `L1OpUSDCFactory.sol` has been deployed to the following addresses:
   - mainnet: `0x7dB8637A5fd20BbDab1176BdF49C943A96F2E9c6`
   - sepolia: `0xC0A9A6cf5d6873523da5B372e326e0668871d377`
+  - base (warning: experimental): `0xf03e6517aCd719Fc93B528Ff35bE5bdB1101754C`
+  - base sepolia (warning: experimental): `0x90eb459fD7ca9E1E19D50035c28418523AC2157f`
 
 _`L1OpUSDCFactory.sol`_ - Factory contract to deploy and setup the `L1OpUSDCBridgeAdapter` contract on L1. Precalculates the addresses of the L2 deployments and triggers their deployment, by sending a transaction to L2.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Chain operators can use the Bridged USDC Standard for the OP Stack to get Bridge
   - mainnet: `0x7dB8637A5fd20BbDab1176BdF49C943A96F2E9c6`
   - sepolia: `0xC0A9A6cf5d6873523da5B372e326e0668871d377`
 
-_`L1OpUSDCFactory.sol`_ - Factory contract to deploy and setup the `L1OpUSDCBridgeAdapter` contract on L1. Precalculates the addresses of the L2 deployments and triggers their deployment, by sending a transaction to L2. It has been deployed to
+_`L1OpUSDCFactory.sol`_ - Factory contract to deploy and setup the `L1OpUSDCBridgeAdapter` contract on L1. Precalculates the addresses of the L2 deployments and triggers their deployment, by sending a transaction to L2.
 
 _`L2OpUSDCDeploy.sol`_ - One time use deployer contract deployed from the L1 factory through a cross-chain deployment. Used as a utility contract for deploying the L2 USDC Proxy, and `L2OpUSDCBridgeAdapter` contract, all at once in its constructor.
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ Chain operators can use the Bridged USDC Standard for the OP Stack to get Bridge
 
 
 ## Contracts
-> :exclamation: `L1OpUSDCFactory.sol` has been deployed to `0x7dB8637A5fd20BbDab1176BdF49C943A96F2E9c6`.
- 
-_`L1OpUSDCFactory.sol`_ - Factory contract to deploy and setup the `L1OpUSDCBridgeAdapter` contract on L1. Precalculates the addresses of the L2 deployments and triggers their deployment, by sending a transaction to L2.
+_`L1OpUSDCFactory.sol`_ - Factory contract to deploy and setup the `L1OpUSDCBridgeAdapter` contract on L1. Precalculates the addresses of the L2 deployments and triggers their deployment, by sending a transaction to L2. It has been deployed to
+  - `0x7dB8637A5fd20BbDab1176BdF49C943A96F2E9c6` on mainnet
+  - `0xC0A9A6cf5d6873523da5B372e326e0668871d377` on sepolia
+  - `0x90eb459fD7ca9E1E19D50035c28418523AC2157f` on base-sepolia
 
 _`L2OpUSDCDeploy.sol`_ - One time use deployer contract deployed from the L1 factory through a cross-chain deployment. Used as a utility contract for deploying the L2 USDC Proxy, and `L2OpUSDCBridgeAdapter` contract, all at once in its constructor.
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ Chain operators can use the Bridged USDC Standard for the OP Stack to get Bridge
 
 
 ## Contracts
+> :exclamation: `L1OpUSDCFactory.sol` has been deployed to the following addresses:
+  - mainnet: `0x7dB8637A5fd20BbDab1176BdF49C943A96F2E9c6`
+  - sepolia: `0xC0A9A6cf5d6873523da5B372e326e0668871d377`
+
 _`L1OpUSDCFactory.sol`_ - Factory contract to deploy and setup the `L1OpUSDCBridgeAdapter` contract on L1. Precalculates the addresses of the L2 deployments and triggers their deployment, by sending a transaction to L2. It has been deployed to
-  - `0x7dB8637A5fd20BbDab1176BdF49C943A96F2E9c6` on mainnet
-  - `0xC0A9A6cf5d6873523da5B372e326e0668871d377` on sepolia
-  - `0x90eb459fD7ca9E1E19D50035c28418523AC2157f` on base-sepolia
 
 _`L2OpUSDCDeploy.sol`_ - One time use deployer contract deployed from the L1 factory through a cross-chain deployment. Used as a utility contract for deploying the L2 USDC Proxy, and `L2OpUSDCBridgeAdapter` contract, all at once in its constructor.
 


### PR DESCRIPTION
Added deployments on `sepolia` and `base-sepolia`
[sepolia: `0xc0a9a6cf5d6873523da5b372e326e0668871d377`](https://sepolia.etherscan.io/address/0xc0a9a6cf5d6873523da5b372e326e0668871d377)
[base sepolia: `0x90eb459fD7ca9E1E19D50035c28418523AC2157f`](https://sepolia.basescan.org/address/0x90eb459fD7ca9E1E19D50035c28418523AC2157f#code)