### PR TITLE
feat: L1, L2 adapter owner

### DIFF
--- a/script/DeployProtocol.s.sol
+++ b/script/DeployProtocol.s.sol
@@ -13,10 +13,11 @@ contract DeployProtocol is Script {
   address public immutable BRIDGED_USDC_IMPLEMENTATION = vm.envAddress('BRIDGED_USDC_IMPLEMENTATION');
   address public immutable L1_MESSENGER = vm.envAddress('L1_MESSENGER');
   string public chainName = vm.envString('CHAIN_NAME');
-  address public owner = vm.rememberKey(vm.envUint('PRIVATE_KEY'));
+  address public l1Owner = vm.envAddress('L1_OWNER');
+  address public l2Owner = vm.envAddress('L2_OWNER');
 
   function run() public {
-    vm.startBroadcast(owner);
+    vm.startBroadcast();
 
     // NOTE: We have these hardcoded to default values, if used in production you will need to change them
     bytes[] memory _usdcInitTxs = new bytes[](3);
@@ -30,7 +31,7 @@ contract DeployProtocol is Script {
     assert(keccak256(_usdcInitTxs[0]) != keccak256(USDCInitTxs.INITIALIZEV2));
 
     IL1OpUSDCFactory.L2Deployments memory _l2Deployments = IL1OpUSDCFactory.L2Deployments({
-      l2AdapterOwner: owner,
+      l2AdapterOwner: l2Owner,
       usdcImplAddr: BRIDGED_USDC_IMPLEMENTATION,
       usdcInitTxs: _usdcInitTxs,
       minGasLimitDeploy: MIN_GAS_LIMIT_DEPLOY
@@ -38,7 +39,7 @@ contract DeployProtocol is Script {
 
     // Deploy the L2 contracts
     (address _l1Adapter, address _l2Deploy, address _l2Adapter) =
-      L1_FACTORY.deploy(L1_MESSENGER, owner, chainName, _l2Deployments);
+      L1_FACTORY.deploy(L1_MESSENGER, l1Owner, chainName, _l2Deployments);
     vm.stopBroadcast();
 
     /// NOTE: Hardcode the newly deployed `_l1Adapter` address on `L1_ADAPTER` inside the `.env` or `env.example` file


### PR DESCRIPTION
This pull request includes changes to the `DeployProtocol` contract in the `script/DeployProtocol.s.sol` file. The main updates involve the separation of L1 and L2 owner addresses and the removal of the owner parameter from the `vm.startBroadcast` function.

Key changes include:

* [`script/DeployProtocol.s.sol`](diffhunk://#diff-d8178c2736b9670e5ba680bb9c218724d810c4068cb1e6fb2295089bf763ff37L16-R20): Replaced the single `owner` address with separate `l1Owner` and `l2Owner` addresses.
* [`script/DeployProtocol.s.sol`](diffhunk://#diff-d8178c2736b9670e5ba680bb9c218724d810c4068cb1e6fb2295089bf763ff37L16-R20): Updated the `run` function to remove the owner parameter from the `vm.startBroadcast` function call.
* [`script/DeployProtocol.s.sol`](diffhunk://#diff-d8178c2736b9670e5ba680bb9c218724d810c4068cb1e6fb2295089bf763ff37L33-R42): Modified the `IL1OpUSDCFactory.L2Deployments` structure to use `l2Owner` instead of `owner`.
* [`script/DeployProtocol.s.sol`](diffhunk://#diff-d8178c2736b9670e5ba680bb9c218724d810c4068cb1e6fb2295089bf763ff37L33-R42): Updated the `L1_FACTORY.deploy` function call to use `l1Owner` instead of `owner`.