### PR TITLE
fix: invalid `multiline_func_header` value

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -5,7 +5,7 @@ bracket_spacing = false
 int_types = 'long'
 quote_style = 'single'
 number_underscore = 'thousands'
-multiline_func_header = 'params_first_multi'
+multiline_func_header = 'params_first'
 sort_imports = true
 
 [profile.default]


### PR DESCRIPTION
This PR fixes invalid multiline_func_header value in the foundry.toml file.

When I try to build the project using yarn build, it shows error log like this.

failed to extract foundry config:
foundry config error: unknown variant: found `params_first_multi`, expected `one of `params_first`, `attributes_first`, `all`` for setting `fmt.multiline_func_header`
Because of using deprecated value for the multiline_func_header.

Fixing issue with changing multiline_func_header to params_first